### PR TITLE
Vagrant docker mesos uid

### DIFF
--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -939,10 +939,9 @@ Vagrant.configure(2) do |config|
       mm_config.vm.provision "ansible" do |ansible|
         ansible.playbook = "deploy_mesos_master.yml"
         ansible.inventory_path = "vagrant_hosts"
-        ansible.extra_vars = {:zookeeper_id => "#{id}"}
+        ansible.extra_vars = {:zookeeper_id => "#{id}", :mesos_master_listen_ip => "0.0.0.0" }.merge(ansible_extra_vars)
         ansible.tags = ansible_tags
         ansible.verbose = ansible_verbosity
-        ansible.extra_vars = ansible_extra_vars
         ansible.limit = ansible_limit
         ansible.skip_tags = ansible_skip
       end

--- a/deploy/Vagrantfile
+++ b/deploy/Vagrantfile
@@ -776,9 +776,7 @@ Vagrant.configure(2) do |config|
     SHELL
 
     cc_config.vm.provision "ansible" do |ansible|
-      ansible_extra_vars = ansible_extra_vars.merge({
-        pp_shared_preload_libraries: "citus"
-      })
+      ansible_extra_vars = { pp_shared_preload_libraries: "citus" }.merge(ansible_extra_vars)
       ansible.playbook = "deploy_citus_server.yml"
       ansible.inventory_path = "vagrant_hosts"
       ansible.tags = ansible_tags
@@ -803,9 +801,7 @@ Vagrant.configure(2) do |config|
     SHELL
 
     cc_config.vm.provision "ansible" do |ansible|
-      ansible_extra_vars = ansible_extra_vars.merge({
-        pp_shared_preload_libraries: "citus"
-      })
+      ansible_extra_vars = { pp_shared_preload_libraries: "citus" }.merge(ansible_extra_vars)
       ansible.playbook = "deploy_citus_server.yml"
       ansible.inventory_path = "vagrant_hosts"
       ansible.tags = ansible_tags
@@ -839,9 +835,7 @@ Vagrant.configure(2) do |config|
       SHELL
 
       cw_config.vm.provision "ansible" do |ansible|
-        ansible_extra_vars = ansible_extra_vars.merge({
-          pp_shared_preload_libraries: "citus"
-        })
+        ansible_extra_vars = { pp_shared_preload_libraries: "citus" }.merge(ansible_extra_vars)
         ansible.playbook = "deploy_citus_server.yml"
         ansible.inventory_path = "vagrant_hosts"
         ansible.tags = ansible_tags

--- a/deploy/deploy_mesos_agent.yml
+++ b/deploy/deploy_mesos_agent.yml
@@ -23,7 +23,7 @@
     - mesos_agent
     - {role: epel7, when: "use_epel and not ( 'production' in group_names or 'developement' in group_names)"}
     - openjdk1.8
-    - postgresql-client7
+    - postgresql-client
     - { role: apache, vars: { apache_service_state: "stopped", apache_service_enable: "no" } }
     #- pentaho
     - gocd7

--- a/deploy/deploy_mesos_master.yml
+++ b/deploy/deploy_mesos_master.yml
@@ -23,14 +23,16 @@
   max_fail_percentage: 30
   roles:
     - {role: iptables, when: "iptables_config"}
-    - { role: epel, when: "use_epel and ( 'production' in group_names or 'developement' in group_names)" } # This is for rhel6 pip
+    - { role: epel7, when: "use_epel and not ( 'production' in group_names or 'developement' in group_names)" } # This is for rhel7 pip
     - common
     - mesos_master
   tasks:
       # used to install kazoo
     - name: Install pip
       yum:
-         name: python-pip
+         name:
+            - python2-pip
+            - python-setuptools
          state: present
 
     - name: Install Kazoo (required by Znode ansible module)
@@ -38,3 +40,4 @@
         name: kazoo
         version: "2.6.1"
         umask: "0022"
+      become: yes

--- a/deploy/roles/mesos_agent/defaults/main.yml
+++ b/deploy/roles/mesos_agent/defaults/main.yml
@@ -29,7 +29,7 @@ marathon_mesos_extra_groups:
 mesos_containerizers: "mesos"
 mesos_launcher: "linux"
 mesos_image_providers: "appc,docker"
-mesos_agent_image_backend: "copy"
+mesos_agent_image_backend: "overlay"
 
 mesos_executor_registration_timeout: 5mins
 

--- a/deploy/roles/mesos_agent/defaults/main.yml
+++ b/deploy/roles/mesos_agent/defaults/main.yml
@@ -21,6 +21,9 @@ mesos_agent_fix_link: True
 
 # User to run processes in Mesos as
 marathon_mesos_user: "mesagent"
+marathon_mesos_uid: "5000"
+marathon_mesos_gid: "5000"
+marathon_mesos_extra_groups:
 
 # Container images
 mesos_containerizers: "mesos"

--- a/deploy/roles/mesos_agent/defaults/main.yml
+++ b/deploy/roles/mesos_agent/defaults/main.yml
@@ -29,7 +29,8 @@ marathon_mesos_extra_groups:
 mesos_containerizers: "mesos"
 mesos_launcher: "linux"
 mesos_image_providers: "appc,docker"
-mesos_agent_image_backend: "overlay"
+mesos_agent_image_backend: "copy"
+mesos_agent_enable_kernelmodule_overlay: False
 
 mesos_executor_registration_timeout: 5mins
 

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -8,7 +8,7 @@
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
   args:
     creates: /etc/yum.repos.d/mesosphere.repo
-  when: not 'production' in group_names
+  #when: not 'production' in group_names
   tags:
     - mesos
     - mesos-agent

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Add mesosphere repository
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
-  creates: /etc/yum.repos.d/mesosphere.repo
+    creates: /etc/yum.repos.d/mesosphere.repo
   when: not 'production' in group_names
   tags:
     - mesos

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -205,9 +205,16 @@
     - mesos
     - mesos-agent
 
+- name: Create mesos main group
+  group:
+    name: "{{ marathon_mesos_user }}"
+    gid: "{{ marathon_mesos_gid }}"
 - name: Create mesos user
   user:
     name: "{{ marathon_mesos_user }}"
+    uid: "{{ marathon_mesos_uid }}"
+    group: "{{ marathon_mesos_user }}"
+    groups: "{{ marathon_mesos_extra_groups }}"
     comment: "Mesos User"
     home: /home/{{ marathon_mesos_user }}
   tags:

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -4,6 +4,11 @@
 ### SETUP MESOS REPOSITORIES AND INSTALL
 
 
+- name: Enable the "overlay" kernel module
+  modprobe:
+    name: overlay
+    state: present
+
 - name: Add mesosphere repository
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
   args:

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -35,6 +35,9 @@
   yum:
     name: yum-plugin-versionlock
     state: present
+  tags:
+    - mesos
+    - mesos-agent
 
 - name: Install mesos packages
   yum:
@@ -51,6 +54,9 @@
 
 - name: Versionlock mesos/marathon packages
   command: yum versionlock mesos* marathon
+  tags:
+    - mesos
+    - mesos-agent
 
 - name: Clean up RPM generated files in the config directory
   file:

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -3,8 +3,10 @@
 
 ### SETUP MESOS REPOSITORIES AND INSTALL
 
+
 - name: Add mesosphere repository
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
+  args:
     creates: /etc/yum.repos.d/mesosphere.repo
   when: not 'production' in group_names
   tags:

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -5,8 +5,7 @@
 
 - name: Add mesosphere repository
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"
-  args:
-    creates: /etc/yum.repos.d/mesosphere.repo
+  creates: /etc/yum.repos.d/mesosphere.repo
   when: not 'production' in group_names
   tags:
     - mesos

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -8,6 +8,9 @@
   modprobe:
     name: overlay
     state: present
+  tags:
+    - mesos
+    - mesos-agent
 
 - name: Add mesosphere repository
   command: "rpm -Uvh http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm"

--- a/deploy/roles/mesos_agent/tasks/main.yml
+++ b/deploy/roles/mesos_agent/tasks/main.yml
@@ -8,6 +8,18 @@
   modprobe:
     name: overlay
     state: present
+  when: mesos_agent_enable_kernelmodule_overlay
+  tags:
+    - mesos
+    - mesos-agent
+
+- name: Enable overlay kernel module after reboot
+  copy:
+    dest: /etc/modules-load.d/overlay.conf
+    content: overlay
+    owner: root
+    group: root
+  when: mesos_agent_enable_kernelmodule_overlay
   tags:
     - mesos
     - mesos-agent
@@ -224,6 +236,10 @@
   group:
     name: "{{ marathon_mesos_user }}"
     gid: "{{ marathon_mesos_gid }}"
+  tags:
+    - mesos
+    - mesos-agent
+
 - name: Create mesos user
   user:
     name: "{{ marathon_mesos_user }}"

--- a/deploy/roles/mesos_master/defaults/main.yml
+++ b/deploy/roles/mesos_master/defaults/main.yml
@@ -19,6 +19,7 @@ mesos_server_packages:
   #- zookeeper-server
 
 mesos_cluster_name: "Test Cluster"
+mesos_master_listen_ip: "{{ aurora_hostname }}"
 mesos_master_port: 5050
 mesos_master_logging_level: "INFO"
 

--- a/deploy/roles/mesos_master/tasks/main.yml
+++ b/deploy/roles/mesos_master/tasks/main.yml
@@ -219,7 +219,7 @@
 - name: Add the ip address to the mesos-master folder
   copy:
     dest: /etc/mesos-master/ip
-    content: "{{ aurora_hostname }}"
+    content: "{{ mesos_master_listen_ip }}"
   notify:
     - restart mesos-master
   tags:

--- a/deploy/roles/nginx/tasks/main.yml
+++ b/deploy/roles/nginx/tasks/main.yml
@@ -1,5 +1,12 @@
 # main.yml - Nginx installation
 ---
+- name: Install yum versionlock plugin
+  yum:
+    name: yum-plugin-versionlock
+    state: present
+  tags:
+    - nginx
+
 - name: Install Nginx
   yum:
     name: "{{ item }}"
@@ -10,6 +17,11 @@
     - nginx
   notify:
     - restart nginx
+  tags:
+    - nginx
+
+- name: Versionlock nginx
+  command: yum versionlock nginx
   tags:
     - nginx
 

--- a/deploy/roles/psql-authnz/tasks/main.yml
+++ b/deploy/roles/psql-authnz/tasks/main.yml
@@ -3,6 +3,11 @@
     name: git
     state: present
 
+- name: Install yum versionlock plugin
+  yum:
+    name: yum-plugin-versionlock
+    state: present
+
 - name: Install dependencies
   yum:
     name: "{{item}}"
@@ -18,5 +23,8 @@
     - libffi-devel
     - openssl-devel
     - openldap-devel
+
+- name: Versionlock libevent
+  command: yum versionlock libevent*
 
 ##ToDO: Add https://github.com/cfpb/psql-authnz deployment steps and run on citus hosts and postgres hosts

--- a/deploy/roles/python-libs7/tasks/main.yml
+++ b/deploy/roles/python-libs7/tasks/main.yml
@@ -14,8 +14,8 @@
   tags:
     - python-libs
 
-- name: Install Python packages dep for othe package for 27 (needed by SLIP)
-  command: scl enable python27 "pip install matplotlib NeuroTools"
+- name: Install Python packages dep for othe package for 27 (needed by SLIP, and for cairocffi)
+  command: scl enable python27 "pip install matplotlib NeuroTools cffi==1.14.4"
   when: install_python
   tags:
     - python-libs

--- a/deploy/roles/python-libs7/tasks/main.yml
+++ b/deploy/roles/python-libs7/tasks/main.yml
@@ -8,8 +8,8 @@
   tags:
     - python-libs
 
-- name: tst Install updated setuptools Python packages for 27 (for pysolr)
-  command: scl enable python27 -- pip install setuptools==12
+- name: tst Install updated pip & setuptools Python packages for 27 (for pysolr)
+  command: scl enable python27 -- pip install pip==20.3.4 setuptools==12
   when: install_python
   tags:
     - python-libs

--- a/deploy/roles/python2rh7/tasks/main.yml
+++ b/deploy/roles/python2rh7/tasks/main.yml
@@ -1,5 +1,11 @@
 # main.yml - Install Python 2.7 and Packages from RedHat Satellite
 ---
+- name: Install Python2 packages (non scl)
+  yum:
+    name:
+        - python2-pip
+        - python2-virtualenv
+
 - name: Install Python27 packages
   yum:
     name: "{{ item }}"

--- a/deploy/roles/python2rh7/tasks/main.yml
+++ b/deploy/roles/python2rh7/tasks/main.yml
@@ -25,7 +25,7 @@
 #    state: present
 - name: SCL Enable Pip Install Upgrade Pip 
   shell: |
-    scl enable python27 -- pip install --upgrade pip
+    scl enable python27 -- pip install pip==20.3.4
   become: yes
   become_method: sudo
 

--- a/deploy/roles/r-shinyRH7/tasks/main.yml
+++ b/deploy/roles/r-shinyRH7/tasks/main.yml
@@ -57,6 +57,15 @@
   tags:
     - shiny
 
+# Shinny rpm install scripts (rpm -q --scripts shiny-server) don't correctly detect systemd on redhat
+# so we are manually installing systemd scripts
+- name: Install systemd script
+  copy:
+    remote_src: "/opt/shiny-server/config/systemd/shiny-server.service"
+    dest: "/etc/systemd/system/shiny-server.service"
+  tags:
+    - shiny
+
 #- name: Create upstart directory
 # file:
 #   dest: /etc/init

--- a/deploy/roles/r-shinyRH7/tasks/main.yml
+++ b/deploy/roles/r-shinyRH7/tasks/main.yml
@@ -61,7 +61,8 @@
 # so we are manually installing systemd scripts
 - name: Install systemd script
   copy:
-    remote_src: "/opt/shiny-server/config/systemd/shiny-server.service"
+    src: "/opt/shiny-server/config/systemd/shiny-server.service"
+    remote_src: True
     dest: "/etc/systemd/system/shiny-server.service"
   tags:
     - shiny

--- a/deploy/roles/r_rh7/meta/main.yml
+++ b/deploy/roles/r_rh7/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-- {role: epel7, when: "use_epel and not 'production' in group_names"}
+  - {role: epel7, when: "use_epel and not 'production' in group_names"}
 # - devtools
 ## devtools7 already installed
   - shared7

--- a/deploy/roles/r_rh7/meta/main.yml
+++ b/deploy/roles/r_rh7/meta/main.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
-# - {role: epel, when: "use_epel and not 'production' in group_names"}
+- {role: epel7, when: "use_epel and not 'production' in group_names"}
 # - devtools
 ## devtools7 already installed
   - shared7

--- a/deploy/roles/r_rh7/tasks/main.yml
+++ b/deploy/roles/r_rh7/tasks/main.yml
@@ -80,6 +80,7 @@
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state: present
     disable_gpg_check: yes
+  when: when: use_epel and "production" not in group_names
     
 - name: Install yum versionlock plugin
   yum:
@@ -320,11 +321,6 @@
 #  become_method: sudo
 #  shell: ldconfig
 
-- name: Ensure epel 7 is installed
-  yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    state: present
-    
 #- name: Install gdal dependencies
 # yum:
 #   name: "{{ item }}"

--- a/deploy/roles/r_rh7/tasks/main.yml
+++ b/deploy/roles/r_rh7/tasks/main.yml
@@ -99,7 +99,7 @@
     - r
 
 - name: Versionlock R, libRMath
-  command: yum versionlock R-* libRMath
+  command: yum versionlock R-* libRmath*
   tags:
     - r
 

--- a/deploy/roles/r_rh7/tasks/main.yml
+++ b/deploy/roles/r_rh7/tasks/main.yml
@@ -81,6 +81,13 @@
     state: present
     disable_gpg_check: yes
     
+- name: Install yum versionlock plugin
+  yum:
+    name: yum-plugin-versionlock
+    state: present
+  tags:
+    - r
+
 # R is a meta package that ensures R-core, R-core-devel, R-java, libRMath, libRMath-devel
 - name: Install R-core
   yum:
@@ -88,6 +95,11 @@
     state: "{{ r_core_state }}"
     disable_gpg_check: yes
   register: r_core_updated
+  tags:
+    - r
+
+- name: Versionlock R, libRMath
+  command: yum versionlock R-* libRMath
   tags:
     - r
 

--- a/deploy/roles/r_rh7/tasks/main.yml
+++ b/deploy/roles/r_rh7/tasks/main.yml
@@ -5,11 +5,15 @@
     line: umask 0022
     regexp: (.*)umask(.*)
     state: present
+  tags:
+    - r-core
 
 - name: check if symbolic link exists
   stat:
     path: /opt/rh/devtoolset-2
   register: devtoolsetlink
+  tags:
+    - r-core
 
 - name: create symbolic link for pointers to /opt/rh/devtoolset-2
   become: yes
@@ -20,26 +24,36 @@
     dest: /opt/rh/devtoolset-2
     state: link
   when: devtoolsetlink.stat.exists == false 
+  tags:
+    - r-core
 
 - name: Download texinfo (1) packages for dependency resolution
   get_url:
     url: http://vault.centos.org/centos/7.6.1810/os/x86_64/Packages/texinfo-tex-5.1-5.el7.x86_64.rpm
     dest: /opt/texinfo-tex-5.1-5.el7.x86_64.rpm
+  tags:
+    - r-core
 
 - name: Download texinfo (2) packages for dependency resolution
   get_url:
     url: http://vault.centos.org/centos/7.6.1810/os/x86_64/Packages/texlive-epsf-doc-svn21461.2.7.4-43.el7.noarch.rpm
     dest: /opt/texlive-epsf-doc-svn21461.2.7.4-43.el7.noarch.rpm
+  tags:
+    - r-core
 
 - name: Download texinfo (3) packages for dependency resolution
   get_url:
     url: http://vault.centos.org/centos/7.6.1810/os/x86_64/Packages/texlive-epsf-svn21461.2.7.4-43.el7.noarch.rpm
     dest: /opt/texlive-epsf-svn21461.2.7.4-43.el7.noarch.rpm
+  tags:
+    - r-core
 
 - name: Download texinfo (4) packages for dependency resolution
   get_url:
     url: http://vault.centos.org/centos/6/os/x86_64/Packages/texlive-texmf-xetex-2007-39.el6_7.noarch.rpm
     dest: /opt/texlive-texmf-xetex-2007-39.el6_7.noarch.rpm
+  tags:
+    - r-core
 
 - name: Install texlive packages
 #  shell:  yum localinstall /opt/texlive* -y
@@ -52,6 +66,8 @@
     url: http://mirrors.ctan.org/support/texlive/texlive-dummy/EnterpriseLinux-7/texlive-dummy-2012a-1.el7.noarch.rpm
     dest: /opt/texlive-dummy-2012a-1.el7.noarch.rpm
 #  http://mirrors.ctan.org/support/texlive/texlive-dummy/EnterpriseLinux-7/texlive-dummy-2012a-1.el7.noarch.rpm
+  tags:
+    - r-core
 
 #- name: Execute texlive dummy rpm
 #  shell: yum localinstall /opt/texlive-dummy-2012a-1.el7.noarch.rpm -y --skip-broken
@@ -81,6 +97,7 @@
     state: present
   tags:
     - r
+    - r-core
 
 # R is a meta package that ensures R-core, R-core-devel, R-java, libRMath, libRMath-devel
 - name: Install R-core
@@ -91,11 +108,13 @@
   register: r_core_updated
   tags:
     - r
+    - r-core
 
 - name: Versionlock R, libRMath
   command: yum versionlock R-* libRmath*
   tags:
     - r
+    - r-core
 
 - name: Check if rstudio server is installed
   yum:
@@ -104,6 +123,7 @@
   register: rstudio_installed
   tags:
     - r
+    - r-core
 
 - name: Restart rstudio if R updates and rstudio server is installed
   command: /bin/true
@@ -112,6 +132,7 @@
   notify: restart rstudio-server
   tags:
     - r
+    - r-core
 
 - name: Install base packages
   yum:
@@ -135,11 +156,13 @@
     - libicu-devel
   tags:
     - r
+    - r-core
 
 - name: Ensure Java is configured
   shell: "R CMD javareconf"
   tags:
     - r
+    - r-core
 
 - name: Ensure that R is executable
   file:
@@ -150,6 +173,7 @@
     - Makeconf
   tags:
     - r
+    - r-core
 
 # Get texlive 2019 install
 - name: Get texlive 2019 binary
@@ -162,6 +186,8 @@
     src: /tmp/install-tl-unx.tar.gz
     dest: /opt
     remote_src: yes
+  tags:
+    - r-core
 
 # texlive installation and dependencies for RedHat 7 are old (2012) and require this deployment to help resolve (texlive-texmf-xetex)
 #- name: Install texlive dependency fixes
@@ -205,6 +231,7 @@
   register: locked_dirs
   tags:
     - r
+    - r-core
 
 - name: Remove locked directories
   file:
@@ -214,6 +241,7 @@
     - "{{ locked_dirs.files }}"
   tags:
     - r
+    - r-core
 
 - name: Update existing R packages
   command: /usr/bin/Rscript --slave --no-save --no-restore-history -e "update.packages(repos=c('http://cran.rstudio.com/'),ask=FALSE,checkBuilt=TRUE);"
@@ -222,6 +250,7 @@
   poll: 60
   tags:
     - r
+    - r-core
   when: install_r_updates
 
 # https://github.com/jeroen/curl/issues/204 ----------------   curl_sslbackend error --------------------
@@ -236,6 +265,7 @@
   environment: "{{ r_env_vars }}"
   tags:
     - r
+    - r-core
   when: install_r_packages and do_r_install_packages
 
 - name: Install R packages with opts
@@ -249,6 +279,7 @@
   environment: "{{ r_env_vars }}"
   tags:
     - r
+    - r-core
   when: install_r_packages and do_r_install_w_opts
 
 - name: Install R packages from Github
@@ -263,6 +294,7 @@
   environment: "{{ r_env_vars }}"
   tags:
     - r
+    - r-core
   when: install_r_packages and do_r_install_github
 
 - name: Re-ensure that R is executable
@@ -274,6 +306,7 @@
     - Makeconf
   tags:
     - r
+    - r-core
   when: install_r_packages
 
 - name: Permissions for R package directory
@@ -287,11 +320,14 @@
   with_items: "{{ r_system_package_dir }}"
   tags:
     - r
+    - r-core
 
 - name: Install pdfgrep
   yum:
     name: pdfgrep
     state: present
+  tags:
+    - r-core
 
 #- name: Get and Build gdal 2.2.1
 #  become: yes

--- a/deploy/roles/r_rh7/tasks/main.yml
+++ b/deploy/roles/r_rh7/tasks/main.yml
@@ -75,13 +75,6 @@
 #- debug:
 #    msg: "R dependencies {{ r_dependencies }}"
 
-- name: Ensure epel7 latest is installed
-  yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    state: present
-    disable_gpg_check: yes
-  when: when: use_epel and "production" not in group_names
-    
 - name: Install yum versionlock plugin
   yum:
     name: yum-plugin-versionlock


### PR DESCRIPTION
 - Mesos user on the agent is pinned to a uid/gid
 - Mesos user can have a list of groups to be added to
 - python2 pip and virtualenv are installed (via epel) available outside of a scl environment
 - Docker/Vagrant port forwarding doesn't like private network ips so overriding mesos to listen on all ips
 - Cleanup variable overriding in the Vagrantfile so those values can be overiden from the commandline
 - Switched mesos image backend from "copy" to "overlay" (stays "copy" on vagrant development)